### PR TITLE
Renaming view to `trailing` and `leading` and adding `rtl` support.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,19 +35,19 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       body: SplitView(
         initialWeight: 0.7,
-        view1: SplitView(
+        leading: SplitView(
           viewMode: SplitViewMode.Horizontal,
-          view1: Container(
+          leading: Container(
             child: Center(child: Text("View1")),
             color: Colors.red,
           ),
-          view2: Container(
+          trailing: Container(
             child: Center(child: Text("View2")),
             color: Colors.blue,
           ),
           onWeightChanged: (w) => print("Horizon: $w"),
         ),
-        view2: Container(
+        trailing: Container(
           child: Center(
             child: Text("View3"),
           ),

--- a/example/lib/main_tabview.dart
+++ b/example/lib/main_tabview.dart
@@ -58,20 +58,20 @@ class _MyHomePageState extends State<MyHomePage> {
             SplitView(
               key: PageStorageKey(0),
               initialWeight: 0.7,
-              view1: SplitView(
+              leading: SplitView(
                 key: PageStorageKey(1),
                 viewMode: SplitViewMode.Horizontal,
-                view1: Container(
+                leading: Container(
                   child: Center(child: Text("View1")),
                   color: Colors.red,
                 ),
-                view2: Container(
+                trailing: Container(
                   child: Center(child: Text("View2")),
                   color: Colors.blue,
                 ),
                 onWeightChanged: (w) => print("Horizon: $w"),
               ),
-              view2: Container(
+              trailing: Container(
                 child: ListView.separated(
                     itemBuilder: (context, index) {
                       return ListTile(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -106,7 +106,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1+2"
+    version: "3.0.0"
   stack_trace:
     dependency: transitive
     description:

--- a/lib/split_view.dart
+++ b/lib/split_view.dart
@@ -6,11 +6,11 @@ import 'package:flutter/widgets.dart';
 
 /// A SplitView class.
 class SplitView extends StatefulWidget {
-  /// The [view1] is first view.
-  final Widget view1;
+  /// The [leading] is first view.
+  final Widget leading;
 
-  /// The [view2] is second view.
-  final Widget view2;
+  /// The [trailing] is second view.
+  final Widget trailing;
 
   /// The [viewMode] specifies how to arrange views.
   final SplitViewMode viewMode;
@@ -50,14 +50,22 @@ class SplitView extends StatefulWidget {
   /// but cannot be specified individually.
   final double positionLimit;
 
+  /// If `TextDirection.ltr` then [leading] is on the left side and [trailing] is on the right side, else
+  /// [trailing] is on the left side and [leading] is on the right side.
+  ///
+  /// If `null`, then the result of `Directionality.of(context)` is used.
+  ///
+  /// If [viewMode] is Vertical, this property will be ignored.
+  final TextDirection? direction;
+
   /// Called when the user moves the grip.
   final ValueChanged<double?>? onWeightChanged;
 
   /// Creates an [SplitView].
   SplitView({
     Key? key,
-    required this.view1,
-    required this.view2,
+    required this.leading,
+    required this.trailing,
     required this.viewMode,
     this.gripSize = 12.0,
     this.minWidthSidebar,
@@ -68,6 +76,7 @@ class SplitView extends StatefulWidget {
     this.gripColor = Colors.grey,
     this.positionLimit = 20.0,
     this.onWeightChanged,
+    this.direction,
   }) : super(key: key);
 
   @override
@@ -135,14 +144,14 @@ class _SplitViewState extends State<SplitView> {
           left: 0,
           right: 0,
           bottom: bottom + halfGripSize,
-          child: widget.view1,
+          child: widget.leading,
         ),
         Positioned(
           top: top + halfGripSize,
           left: 0,
           right: 0,
           bottom: 0,
-          child: widget.view2,
+          child: widget.trailing,
         ),
         Positioned(
           top: top - halfGripSize,
@@ -185,6 +194,14 @@ class _SplitViewState extends State<SplitView> {
       right = constraints.maxWidth - widget.minWidthSidebar!;
     }
 
+    final directionality = Directionality.of(context);
+
+    final leftView =
+        directionality == TextDirection.ltr ? widget.leading : widget.trailing;
+
+    final rightView =
+        directionality == TextDirection.ltr ? widget.trailing : widget.leading;
+
     return Stack(
       children: <Widget>[
         Positioned(
@@ -192,14 +209,14 @@ class _SplitViewState extends State<SplitView> {
           left: 0,
           right: right + halfGripSize,
           bottom: 0,
-          child: widget.view1,
+          child: leftView,
         ),
         Positioned(
           top: 0,
           left: left + halfGripSize,
           right: 0,
           bottom: 0,
-          child: widget.view2,
+          child: rightView,
         ),
         Positioned(
           top: 0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: split_view
 description: This wedget provides horizontal or vertical split view for flutter.
-version: 2.0.1+2
+version: 3.0.0
 homepage: https://github.com/toshiaki-h/split_view
 
 environment:


### PR DESCRIPTION
I renamed `view1` and `view2` to `trailing` and `leading`, which I find more clear (*we already have those terms in [SliverAppBar](https://api.flutter.dev/flutter/material/SliverAppBar/leading.html) [GridTileBar],(https://api.flutter.dev/flutter/material/GridTileBar/leading.html), [ListTile](https://api.flutter.dev/flutter/material/ListTile/leading.html) for example*).

This PR also adds `rtl` support which means that leading and trailing views are inverted when the text direction of the application is `rtl` and the mode is horizontal.