### PR TITLE
Fix rebuild with new controller

### DIFF
--- a/lib/split_view.dart
+++ b/lib/split_view.dart
@@ -99,8 +99,10 @@ class _SplitViewState extends State<SplitView> {
           weights: _controller.weights,
           limits: _controller.limits,
         );
-      } else if (widget.controller != null && oldWidget.controller == null) {
-        _controller.dispose();
+      } else {
+        if (widget.controller != null && oldWidget.controller == null) {
+          _controller.dispose();
+        }
         _controller = widget.controller!;
       }
     }

--- a/test/split_view_test.dart
+++ b/test/split_view_test.dart
@@ -35,4 +35,57 @@ void main() {
     expect(tester.getSize(find.byKey(ValueKey(1))).width, totalWidth * 0.4);
     expect(tester.getSize(find.byKey(ValueKey(2))).width, totalWidth * 0.5);
   });
+
+  testWidgets('rebuild', (tester) async {
+    final controller1 = SplitViewController(weights: [0.2, 0.8]);
+    final controller2 = SplitViewController(weights: [0.4, 0.6]);
+
+    Future<void> pumpSplitView(SplitViewController controller) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SplitView(
+              gripSize: 10,
+              controller: controller,
+              viewMode: SplitViewMode.Horizontal,
+              indicator: const SizedBox.shrink(key: Key('indicator')),
+              children: [
+                Container(key: ValueKey(0)),
+                Container(key: ValueKey(2)),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    await pumpSplitView(controller1);
+
+    expect(controller1.weights, [0.2, 0.8]);
+    expect(controller2.weights, [0.4, 0.6]);
+
+    final indicator = find.ancestor(
+      of: find.byKey(const Key('indicator')),
+      matching: find.byType(Container),
+    );
+    expect(indicator, findsOneWidget);
+
+    // drag to the right (controller1)
+    await tester.drag(indicator, Offset(10, 0));
+
+    final weights1 = controller1.weights;
+    expect(weights1.first, greaterThan(0.2));
+    expect(weights1.last, lessThan(0.8));
+    expect(controller2.weights, [0.4, 0.6]);
+
+    await pumpSplitView(controller2);
+
+    // drag to the left (controller2)
+    await tester.drag(indicator, Offset(-20, 0));
+
+    expect(controller1.weights, equals(weights1));
+    final weights2 = controller2.weights;
+    expect(weights2.first, lessThan(0.4));
+    expect(weights2.last, greaterThan(0.6));
+  });
 }


### PR DESCRIPTION
When rebuilding SplitView with an inline-constructed controller, the new
controller was not assigned to `_SplitViewState._controller` and thus,
did not get notified of moves after the first rebuild.

Fixes: #19